### PR TITLE
fix the nil_ls rename issue

### DIFF
--- a/config/plug/lsp/lsp.nix
+++ b/config/plug/lsp/lsp.nix
@@ -7,7 +7,7 @@
         eslint = {enable = true;};
         html = {enable = true;};
         lua-ls = {enable = true;};
-        nil_ls = {enable = true;};
+        nil-ls = {enable = true;};
         marksman = {enable = true;};
         pyright = {enable = true;};
         gopls = {enable = true;};


### PR DESCRIPTION

![Screenshot from 2024-06-08 13-35-37](https://github.com/elythh/nixvim/assets/32416397/bc7242b9-0f3a-46af-97c7-d52a6569c8b5)

Fix the `plugins.lsp.servers.nil_ls` warning issue. 

The checkout full error looks like this:

> The option defined in `/nix/store/n1n9qp533624azrv8gr1mlq08vhfjrpf-source/config/plug/lsp/lsp.nix` has been renamed to `plugins.lsp.servers.nil-ls`.
