### PR TITLE
🔧 (markview): update

### DIFF
--- a/config/plug/utils/markview.nix
+++ b/config/plug/utils/markview.nix
@@ -2,12 +2,12 @@
   extraPlugins = with pkgs.vimUtils; [
     (buildVimPlugin {
       pname = "markview.nvim";
-      version = "0.0.1";
+      version = "1.0.0";
       src = pkgs.fetchFromGitHub {
         owner = "OXY2DEV";
         repo = "markview.nvim";
-        rev = "8537f7f03e4683b9ef98202e7a0286373a5b7135";
-        hash = "sha256-keMlFGBcu9ZXdiwbGYE+qBrGeo55+qhE/JgFeb+4fhM=";
+        rev = "refs/tags/v${version}";
+        hash = "sha256-mhRg/cszW/3oXdC1yvbpCeqWQA9WLW5FvcqGd/wBTnE=";
       };
     })
   ];


### PR DESCRIPTION
Switch to using `refs/tags/v${version}` as [OXY2DEV/markview.nvim](https://github.com/OXY2DEV/markview.nvim) released a tag [v1.0.0](https://github.com/OXY2DEV/markview.nvim/releases/tag/v1.0.0) 2 days ago[^1]

Changelog: https://github.com/OXY2DEV/markview.nvim/releases/tag/v1.0.0
Diff: https://github.com/OXY2DEV/markview.nvim/compare/8537f7f03e4683b9ef98202e7a0286373a5b7135...v1.0.0

[^1]: 31 July 2024 at 5:53 UTC