### PR TITLE
📦 {flake,conform}: use nixfmt-rfc-style; 💄 (treewide): format with nixfmt-rfc-style

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -1,7 +1,5 @@
-{ config
-, lib
-, ...
-}: {
+{ config, lib, ... }:
+{
   imports = [
     ./autocommands.nix
     ./keys.nix
@@ -67,11 +65,25 @@
   options = {
     theme = lib.mkOption {
       default = lib.mkDefault "paradise";
-      type = lib.types.enum [ "paradise" "decay" "edge-dark" "mountain" "tokyonight" "everforest" "everblush" "jellybeans" "aquarium" "gruvbox" ];
+      type = lib.types.enum [
+        "paradise"
+        "decay"
+        "edge-dark"
+        "mountain"
+        "tokyonight"
+        "everforest"
+        "everblush"
+        "jellybeans"
+        "aquarium"
+        "gruvbox"
+      ];
     };
     assistant = lib.mkOption {
       default = "none";
-      type = lib.types.enum [ "copilot" "none" ];
+      type = lib.types.enum [
+        "copilot"
+        "none"
+      ];
     };
   };
   config = {

--- a/config/highlight.nix
+++ b/config/highlight.nix
@@ -1,7 +1,4 @@
-{ config
-, lib
-, ...
-}:
+{ config, lib, ... }:
 let
   colors = import ../config/colors/${config.theme}.nix { };
 in

--- a/config/keys.nix
+++ b/config/keys.nix
@@ -22,7 +22,10 @@
     }
 
     {
-      mode = [ "n" "v" ];
+      mode = [
+        "n"
+        "v"
+      ];
       key = "<leader>g";
       action = "+git";
     }
@@ -46,19 +49,28 @@
     }
 
     {
-      mode = [ "n" "v" ];
+      mode = [
+        "n"
+        "v"
+      ];
       key = "<leader>d";
       action = "+debug";
     }
 
     {
-      mode = [ "n" "v" ];
+      mode = [
+        "n"
+        "v"
+      ];
       key = "<leader>c";
       action = "+code";
     }
 
     {
-      mode = [ "n" "v" ];
+      mode = [
+        "n"
+        "v"
+      ];
       key = "<leader>t";
       action = "+test";
     }
@@ -220,14 +232,18 @@
       mode = "v";
       key = "J";
       action = ":m '>+1<CR>gv=gv";
-      options = { desc = "Use move command when line is highlighted "; };
+      options = {
+        desc = "Use move command when line is highlighted ";
+      };
     }
 
     {
       mode = "v";
       key = "K";
       action = ":m '>-2<CR>gv=gv";
-      options = { desc = "Use move command when line is highlighted "; };
+      options = {
+        desc = "Use move command when line is highlighted ";
+      };
     }
 
     {
@@ -261,14 +277,18 @@
       mode = "n";
       key = "n";
       action = "nzzzv";
-      options = { desc = "Allow search terms to stay in the middle "; };
+      options = {
+        desc = "Allow search terms to stay in the middle ";
+      };
     }
 
     {
       mode = "n";
       key = "N";
       action = "Nzzzv";
-      options = { desc = "Allow search terms to stay in the middle "; };
+      options = {
+        desc = "Allow search terms to stay in the middle ";
+      };
     }
 
     # Paste stuff without saving the deleted word into the buffer
@@ -276,30 +296,47 @@
       mode = "x";
       key = "<leader>p";
       action = ''"_dP'';
-      options = { desc = "Deletes to void register and paste over"; };
+      options = {
+        desc = "Deletes to void register and paste over";
+      };
     }
 
     # Copy stuff to system clipboard with <leader> + y or just y to have it just in vim
     {
-      mode = [ "n" "v" ];
+      mode = [
+        "n"
+        "v"
+      ];
       key = "<leader>y";
       action = ''"+y'';
-      options = { desc = "Copy to system clipboard"; };
+      options = {
+        desc = "Copy to system clipboard";
+      };
     }
 
     {
-      mode = [ "n" "v" ];
+      mode = [
+        "n"
+        "v"
+      ];
       key = "<leader>Y";
       action = ''"+Y'';
-      options = { desc = "Copy to system clipboard"; };
+      options = {
+        desc = "Copy to system clipboard";
+      };
     }
 
     # Delete to void register
     {
-      mode = [ "n" "v" ];
+      mode = [
+        "n"
+        "v"
+      ];
       key = "<leader>D";
       action = ''"_d'';
-      options = { desc = "Delete to void register"; };
+      options = {
+        desc = "Delete to void register";
+      };
     }
 
     # <C-c> instead of pressing esc just because
@@ -313,63 +350,81 @@
       mode = "n";
       key = "<leader>m";
       action = "<CMD> Grapple toggle <CR>";
-      options = { desc = "Grapple Toggle tag"; };
+      options = {
+        desc = "Grapple Toggle tag";
+      };
     }
 
     {
       mode = "n";
       key = "<leader>k";
       action = "<CMD> Grapple toggle_tags <CR>";
-      options = { desc = "Grapple Toggle tag"; };
+      options = {
+        desc = "Grapple Toggle tag";
+      };
     }
 
     {
       mode = "n";
       key = "<leader>K";
       action = "<CMD> Grapple toggle_scopes <CR>";
-      options = { desc = "Grapple Toggle scopes"; };
+      options = {
+        desc = "Grapple Toggle scopes";
+      };
     }
 
     {
       mode = "n";
       key = "<leader>j";
       action = "<CMD> Grapple cycle forward <CR>";
-      options = { desc = "Grapple Cycle forward"; };
+      options = {
+        desc = "Grapple Cycle forward";
+      };
     }
 
     {
       mode = "n";
       key = "<leader>J";
       action = "<CMD> Grapple cycle backward <CR>";
-      options = { desc = "Grapple Cycle backward"; };
+      options = {
+        desc = "Grapple Cycle backward";
+      };
     }
 
     {
       mode = "n";
       key = "<leader>1";
       action = "<CMD> Grapple select index=1<CR>";
-      options = { desc = "Grapple Select 1"; };
+      options = {
+        desc = "Grapple Select 1";
+      };
     }
 
     {
       mode = "n";
       key = "<leader>2";
       action = "<CMD> Grapple select index=2<CR>";
-      options = { desc = "Grapple Select 2"; };
+      options = {
+        desc = "Grapple Select 2";
+      };
     }
 
     {
       mode = "n";
       key = "<leader>3";
       action = "<CMD> Grapple select index=3<CR>";
-      options = { desc = "Grapple Select 3"; };
+      options = {
+        desc = "Grapple Select 3";
+      };
     }
 
     {
       mode = "n";
       key = "<leader>4";
       action = "<CMD> Grapple select index=4<CR>";
-      options = { desc = "Grapple Select 4"; };
+      options = {
+        desc = "Grapple Select 4";
+      };
     }
   ];
   extraConfigLua = ''

--- a/config/plug/colorscheme/biscuit.nix
+++ b/config/plug/colorscheme/biscuit.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+{
   extraPlugins = with pkgs.vimUtils; [
     (buildVimPlugin {
       pname = "biscuit.nvim";

--- a/config/plug/colorscheme/colorscheme.nix
+++ b/config/plug/colorscheme/colorscheme.nix
@@ -58,7 +58,7 @@ in
     rose-pine = {
       enable = false;
       settings = {
-        style = "main"; #  "main", "moon", "dawn" or raw lua code
+        style = "main"; # "main", "moon", "dawn" or raw lua code
         styles = {
           bold = false;
           italic = false;

--- a/config/plug/completion/cmp.nix
+++ b/config/plug/completion/cmp.nix
@@ -1,18 +1,30 @@
 {
   plugins = {
-    cmp-emoji = { enable = true; };
+    cmp-emoji = {
+      enable = true;
+    };
     cmp = {
       enable = true;
       settings = {
         autoEnableSources = true;
-        experimental = { ghost_text = true; };
+        experimental = {
+          ghost_text = true;
+        };
         performance = {
           debounce = 60;
           fetchingTimeout = 200;
           maxViewEntries = 30;
         };
-        snippet = { expand = "luasnip"; };
-        formatting = { fields = [ "kind" "abbr" "menu" ]; };
+        snippet = {
+          expand = "luasnip";
+        };
+        formatting = {
+          fields = [
+            "kind"
+            "abbr"
+            "menu"
+          ];
+        };
         sources = [
           { name = "nvim_lsp"; }
           { name = "emoji"; }
@@ -33,8 +45,12 @@
         ];
 
         window = {
-          completion = { border = "solid"; };
-          documentation = { border = "solid"; };
+          completion = {
+            border = "solid";
+          };
+          documentation = {
+            border = "solid";
+          };
         };
 
         mapping = {
@@ -50,11 +66,21 @@
         };
       };
     };
-    cmp-nvim-lsp = { enable = true; }; # lsp
-    cmp-buffer = { enable = true; };
-    cmp-path = { enable = true; }; # file system paths
-    cmp_luasnip = { enable = true; }; # snippets
-    cmp-cmdline = { enable = false; }; # autocomplete for cmdline
+    cmp-nvim-lsp = {
+      enable = true;
+    }; # lsp
+    cmp-buffer = {
+      enable = true;
+    };
+    cmp-path = {
+      enable = true;
+    }; # file system paths
+    cmp_luasnip = {
+      enable = true;
+    }; # snippets
+    cmp-cmdline = {
+      enable = false;
+    }; # autocomplete for cmdline
   };
   extraConfigLua = ''
           luasnip = require("luasnip")

--- a/config/plug/completion/copilot-cmp.nix
+++ b/config/plug/completion/copilot-cmp.nix
@@ -4,8 +4,12 @@
   };
   plugins.copilot-lua = {
     enable = true;
-    suggestion = { enabled = false; };
-    panel = { enabled = false; };
+    suggestion = {
+      enabled = false;
+    };
+    panel = {
+      enabled = false;
+    };
   };
 
   extraConfigLua = ''

--- a/config/plug/git/gitsigns.nix
+++ b/config/plug/git/gitsigns.nix
@@ -28,7 +28,10 @@
   };
   keymaps = [
     {
-      mode = [ "n" "v" ];
+      mode = [
+        "n"
+        "v"
+      ];
       key = "<leader>gh";
       action = "gitsigns";
       options = {

--- a/config/plug/lsp/conform.nix
+++ b/config/plug/lsp/conform.nix
@@ -16,7 +16,7 @@
       typescriptreact = [ [ "prettierd" "prettier" ] ];
       python = [ "black" ];
       lua = [ "stylua" ];
-      nix = [ "nixpkgs-fmt" ];
+      nix = [ "nixfmt" ];
       markdown = [ [ "prettierd" "prettier" ] ];
       yaml = [ "yamllint" "yamlfmt" ];
     };

--- a/config/plug/lsp/conform.nix
+++ b/config/plug/lsp/conform.nix
@@ -8,17 +8,55 @@
     notifyOnError = true;
     formattersByFt = {
       liquidsoap = [ "liquidsoap-prettier" ];
-      html = [ [ "prettierd" "prettier" ] ];
-      css = [ [ "prettierd" "prettier" ] ];
-      javascript = [ [ "prettierd" "prettier" ] ];
-      javascriptreact = [ [ "prettierd" "prettier" ] ];
-      typescript = [ [ "prettierd" "prettier" ] ];
-      typescriptreact = [ [ "prettierd" "prettier" ] ];
+      html = [
+        [
+          "prettierd"
+          "prettier"
+        ]
+      ];
+      css = [
+        [
+          "prettierd"
+          "prettier"
+        ]
+      ];
+      javascript = [
+        [
+          "prettierd"
+          "prettier"
+        ]
+      ];
+      javascriptreact = [
+        [
+          "prettierd"
+          "prettier"
+        ]
+      ];
+      typescript = [
+        [
+          "prettierd"
+          "prettier"
+        ]
+      ];
+      typescriptreact = [
+        [
+          "prettierd"
+          "prettier"
+        ]
+      ];
       python = [ "black" ];
       lua = [ "stylua" ];
       nix = [ "nixfmt" ];
-      markdown = [ [ "prettierd" "prettier" ] ];
-      yaml = [ "yamllint" "yamlfmt" ];
+      markdown = [
+        [
+          "prettierd"
+          "prettier"
+        ]
+      ];
+      yaml = [
+        "yamllint"
+        "yamlfmt"
+      ];
     };
   };
 }

--- a/config/plug/lsp/fidget.nix
+++ b/config/plug/lsp/fidget.nix
@@ -3,7 +3,7 @@
     enable = true;
     logger = {
       level = "warn"; # “off”, “error”, “warn”, “info”, “debug”, “trace”
-      floatPrecision = 0.01; # Limit the number of decimals displayed for floats
+      floatPrecision = 1.0e-2; # Limit the number of decimals displayed for floats
     };
     progress = {
       pollRate = 0; # How and when to poll for progress messages

--- a/config/plug/lsp/hlchunk.nix
+++ b/config/plug/lsp/hlchunk.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+{
   extraPlugins = [
     (pkgs.vimUtils.buildVimPlugin {
       name = "hlchunk";

--- a/config/plug/lsp/lsp.nix
+++ b/config/plug/lsp/lsp.nix
@@ -1,18 +1,38 @@
 {
   plugins = {
-    lsp-format = { enable = true; };
+    lsp-format = {
+      enable = true;
+    };
     lsp = {
       enable = true;
       servers = {
-        eslint = { enable = true; };
-        html = { enable = true; };
-        lua-ls = { enable = true; };
-        nil-ls = { enable = true; };
-        marksman = { enable = true; };
-        pyright = { enable = true; };
-        gopls = { enable = true; };
-        terraformls = { enable = true; };
-        tsserver = { enable = false; };
+        eslint = {
+          enable = true;
+        };
+        html = {
+          enable = true;
+        };
+        lua-ls = {
+          enable = true;
+        };
+        nil-ls = {
+          enable = true;
+        };
+        marksman = {
+          enable = true;
+        };
+        pyright = {
+          enable = true;
+        };
+        gopls = {
+          enable = true;
+        };
+        terraformls = {
+          enable = true;
+        };
+        tsserver = {
+          enable = false;
+        };
         yamlls = {
           enable = true;
         };

--- a/config/plug/lsp/lspsaga.nix
+++ b/config/plug/lsp/lspsaga.nix
@@ -27,7 +27,10 @@
       numShortcut = true;
       keys = {
         exec = "<CR>";
-        quit = [ "<Esc>" "q" ];
+        quit = [
+          "<Esc>"
+          "q"
+        ];
       };
     };
     lightbulb = {
@@ -42,7 +45,10 @@
       autoSave = false;
       keys = {
         exec = "<CR>";
-        quit = [ "<C-k>" "<Esc>" ];
+        quit = [
+          "<C-k>"
+          "<Esc>"
+        ];
         select = "x";
       };
     };

--- a/config/plug/lsp/none-ls.nix
+++ b/config/plug/lsp/none-ls.nix
@@ -40,7 +40,10 @@
   };
   keymaps = [
     {
-      mode = [ "n" "v" ];
+      mode = [
+        "n"
+        "v"
+      ];
       key = "<leader>cf";
       action = "<cmd>lua vim.lsp.buf.format()<cr>";
       options = {

--- a/config/plug/snippets/luasnip.nix
+++ b/config/plug/snippets/luasnip.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+{
   plugins.luasnip = {
     enable = true;
     extraConfig = {

--- a/config/plug/statusline/lualine.nix
+++ b/config/plug/statusline/lualine.nix
@@ -7,7 +7,11 @@ in
     enable = true;
     globalstatus = true;
     disabledFiletypes = {
-      statusline = [ "dashboard" "alpha" "starter" ];
+      statusline = [
+        "dashboard"
+        "alpha"
+        "starter"
+      ];
     };
     theme = {
       normal = {
@@ -35,14 +39,8 @@ in
           name = "mode";
           fmt = "string.lower";
           color = {
-            fg =
-              if config.colorschemes.base16.enable
-              then colors.base04
-              else "none";
-            bg =
-              if config.colorschemes.base16.enable
-              then colors.base00
-              else "none";
+            fg = if config.colorschemes.base16.enable then colors.base04 else "none";
+            bg = if config.colorschemes.base16.enable then colors.base00 else "none";
           };
         }
       ];
@@ -51,14 +49,8 @@ in
           name = "branch";
           icon = "";
           color = {
-            fg =
-              if config.colorschemes.base16.enable
-              then colors.base04
-              else "none";
-            bg =
-              if config.colorschemes.base16.enable
-              then colors.base00
-              else "none";
+            fg = if config.colorschemes.base16.enable then colors.base04 else "none";
+            bg = if config.colorschemes.base16.enable then colors.base00 else "none";
           };
         }
         "diff"
@@ -75,14 +67,8 @@ in
             };
           };
           color = {
-            fg =
-              if config.colorschemes.base16.enable
-              then colors.base08
-              else "none";
-            bg =
-              if config.colorschemes.base16.enable
-              then colors.base00
-              else "none";
+            fg = if config.colorschemes.base16.enable then colors.base08 else "none";
+            bg = if config.colorschemes.base16.enable then colors.base00 else "none";
           };
         }
       ];
@@ -105,14 +91,8 @@ in
             };
           };
           color = {
-            fg =
-              if config.colorschemes.base16.enable
-              then colors.base04
-              else "none";
-            bg =
-              if config.colorschemes.base16.enable
-              then colors.base00
-              else "none";
+            fg = if config.colorschemes.base16.enable then colors.base04 else "none";
+            bg = if config.colorschemes.base16.enable then colors.base00 else "none";
           };
           separator.left = "";
         }
@@ -121,14 +101,8 @@ in
         {
           name = "location";
           color = {
-            fg =
-              if config.colorschemes.base16.enable
-              then colors.base0B
-              else "none";
-            bg =
-              if config.colorschemes.base16.enable
-              then colors.base00
-              else "none";
+            fg = if config.colorschemes.base16.enable then colors.base0B else "none";
+            bg = if config.colorschemes.base16.enable then colors.base00 else "none";
           };
         }
       ];

--- a/config/plug/statusline/staline.nix
+++ b/config/plug/statusline/staline.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+{
   extraPlugins = with pkgs.vimUtils; [
     (buildVimPlugin {
       pname = "staline.nvim";

--- a/config/plug/ui/alpha.nix
+++ b/config/plug/ui/alpha.nix
@@ -60,20 +60,10 @@
               };
             in
             [
-              (
-                mkButton
-                  "f"
-                  "<CMD>lua require('telescope.builtin').find_files({hidden = true})<CR>"
-                  "🔍 Find File"
-                  "Operator"
+              (mkButton "f" "<CMD>lua require('telescope.builtin').find_files({hidden = true})<CR>" "🔍 Find File"
+                "Operator"
               )
-              (
-                mkButton
-                  "q"
-                  "<CMD>qa<CR>"
-                  "💣 Quit Neovim"
-                  "String"
-              )
+              (mkButton "q" "<CMD>qa<CR>" "💣 Quit Neovim" "String")
             ];
         }
         {

--- a/config/plug/ui/btw.nix
+++ b/config/plug/ui/btw.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+{
   extraPlugins = with pkgs.vimUtils; [
     (buildVimPlugin {
       pname = "btw.nvim";

--- a/config/plug/ui/bufferline.nix
+++ b/config/plug/ui/bufferline.nix
@@ -1,7 +1,4 @@
-{ config
-, lib
-, ...
-}:
+{ config, lib, ... }:
 let
   colors = import ../../colors/${config.theme}.nix { };
 in

--- a/config/plug/ui/noice.nix
+++ b/config/plug/ui/noice.nix
@@ -22,12 +22,26 @@
     };
     format = {
       filter = {
-        pattern = [ ":%s*%%s*s:%s*" ":%s*%%s*s!%s*" ":%s*%%s*s/%s*" "%s*s:%s*" ":%s*s!%s*" ":%s*s/%s*" ];
+        pattern = [
+          ":%s*%%s*s:%s*"
+          ":%s*%%s*s!%s*"
+          ":%s*%%s*s/%s*"
+          "%s*s:%s*"
+          ":%s*s!%s*"
+          ":%s*s/%s*"
+        ];
         icon = "";
         lang = "regex";
       };
       replace = {
-        pattern = [ ":%s*%%s*s:%w*:%s*" ":%s*%%s*s!%w*!%s*" ":%s*%%s*s/%w*/%s*" "%s*s:%w*:%s*" ":%s*s!%w*!%s*" ":%s*s/%w*/%s*" ];
+        pattern = [
+          ":%s*%%s*s:%w*:%s*"
+          ":%s*%%s*s!%w*!%s*"
+          ":%s*%%s*s/%w*/%s*"
+          "%s*s:%w*:%s*"
+          ":%s*s!%w*!%s*"
+          ":%s*s/%w*/%s*"
+        ];
         icon = "󱞪";
         lang = "regex";
       };

--- a/config/plug/ui/nvim-notify.nix
+++ b/config/plug/ui/nvim-notify.nix
@@ -27,19 +27,19 @@
     -- Override notify function to filter out messages
     ---@diagnostic disable-next-line: duplicate-set-field
     vim.notify = function(message, level, opts)
-    	local merged_opts = vim.tbl_extend("force", {
-    		on_open = function(win)
-    			local buf = vim.api.nvim_win_get_buf(win)
-    			vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
-    		end,
-    	}, opts or {})
+      local merged_opts = vim.tbl_extend("force", {
+        on_open = function(win)
+          local buf = vim.api.nvim_win_get_buf(win)
+          vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
+        end,
+      }, opts or {})
 
-    	for _, msg in ipairs(filtered_message) do
-    		if message == msg then
-    			return
-    		end
-    	end
-    	return notify(message, level, merged_opts)
+      for _, msg in ipairs(filtered_message) do
+        if message == msg then
+          return
+        end
+      end
+      return notify(message, level, merged_opts)
     end
   '';
 }

--- a/config/plug/ui/precognition.nix
+++ b/config/plug/ui/precognition.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+{
   extraPlugins = with pkgs.vimUtils; [
     (buildVimPlugin {
       pname = "precognition.nvim";

--- a/config/plug/utils/copilot.nix
+++ b/config/plug/utils/copilot.nix
@@ -1,7 +1,8 @@
-{ pkgs
-, config
-, lib
-, ...
+{
+  pkgs,
+  config,
+  lib,
+  ...
 }:
 let
   copilotChatRepo = {

--- a/config/plug/utils/flash.nix
+++ b/config/plug/utils/flash.nix
@@ -18,7 +18,11 @@
   };
   keymaps = [
     {
-      mode = [ "n" "x" "o" ];
+      mode = [
+        "n"
+        "x"
+        "o"
+      ];
       key = "s";
       action = "<cmd>lua require('flash').jump()<cr>";
       options = {
@@ -27,7 +31,11 @@
     }
 
     {
-      mode = [ "n" "x" "o" ];
+      mode = [
+        "n"
+        "x"
+        "o"
+      ];
       key = "S";
       action = "<cmd>lua require('flash').treesitter()<cr>";
       options = {
@@ -45,7 +53,10 @@
     }
 
     {
-      mode = [ "x" "o" ];
+      mode = [
+        "x"
+        "o"
+      ];
       key = "R";
       action = "<cmd>lua require('flash').treesitter_search()<cr>";
       options = {

--- a/config/plug/utils/grapple.nix
+++ b/config/plug/utils/grapple.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+{
   extraPlugins = with pkgs.vimUtils; [
     (buildVimPlugin {
       pname = "grapple.nvim";

--- a/config/plug/utils/hardtime.nix
+++ b/config/plug/utils/hardtime.nix
@@ -1,4 +1,5 @@
-{ lib, ... }: {
+{ lib, ... }:
+{
   plugins.hardtime = {
     enable = lib.mkDefault false;
     enabled = true;
@@ -9,18 +10,54 @@
     maxTime = 1000;
     restrictionMode = "hint";
     restrictedKeys = {
-      "h" = [ "n" "x" ];
-      "j" = [ "n" "x" ];
-      "k" = [ "n" "x" ];
-      "l" = [ "n" "x" ];
-      "-" = [ "n" "x" ];
-      "+" = [ "n" "x" ];
-      "gj" = [ "n" "x" ];
-      "gk" = [ "n" "x" ];
-      "<CR>" = [ "n" "x" ];
-      "<C-M>" = [ "n" "x" ];
-      "<C-N>" = [ "n" "x" ];
-      "<C-P>" = [ "n" "x" ];
+      "h" = [
+        "n"
+        "x"
+      ];
+      "j" = [
+        "n"
+        "x"
+      ];
+      "k" = [
+        "n"
+        "x"
+      ];
+      "l" = [
+        "n"
+        "x"
+      ];
+      "-" = [
+        "n"
+        "x"
+      ];
+      "+" = [
+        "n"
+        "x"
+      ];
+      "gj" = [
+        "n"
+        "x"
+      ];
+      "gk" = [
+        "n"
+        "x"
+      ];
+      "<CR>" = [
+        "n"
+        "x"
+      ];
+      "<C-M>" = [
+        "n"
+        "x"
+      ];
+      "<C-N>" = [
+        "n"
+        "x"
+      ];
+      "<C-P>" = [
+        "n"
+        "x"
+      ];
     };
   };
 }

--- a/config/plug/utils/markview.nix
+++ b/config/plug/utils/markview.nix
@@ -1,6 +1,7 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+{
   extraPlugins = with pkgs.vimUtils; [
-    (buildVimPlugin rec{
+    (buildVimPlugin rec {
       pname = "markview.nvim";
       version = "1.0.0";
       src = pkgs.fetchFromGitHub {

--- a/config/plug/utils/obsidian.nix
+++ b/config/plug/utils/obsidian.nix
@@ -1,4 +1,5 @@
-{ lib, ... }: {
+{ lib, ... }:
+{
   plugins.obsidian = {
     enable = lib.mkDefault false;
     settings = {

--- a/config/plug/utils/yaml-companion.nix
+++ b/config/plug/utils/yaml-companion.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+{
   extraPlugins = with pkgs.vimUtils; [
     (buildVimPlugin {
       pname = "yaml-companion";

--- a/config/sets.nix
+++ b/config/sets.nix
@@ -42,7 +42,11 @@
       updatetime = 50; # faster completion (4000ms default)
 
       # Set completeopt to have a better completion experience
-      completeopt = [ "menuone" "noselect" "noinsert" ]; # mostly just for cmp
+      completeopt = [
+        "menuone"
+        "noselect"
+        "noinsert"
+      ]; # mostly just for cmp
 
       # Enable persistent undo history
       swapfile = false;

--- a/flake.nix
+++ b/flake.nix
@@ -15,21 +15,28 @@
   };
 
   outputs =
-    { nixpkgs
-    , nixvim
-    , flake-parts
-    , pre-commit-hooks
-    , ...
-    } @ inputs:
+    {
+      nixpkgs,
+      nixvim,
+      flake-parts,
+      pre-commit-hooks,
+      ...
+    }@inputs:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
 
       perSystem =
-        { system
-        , pkgs
-        , self'
-        , lib
-        , ...
+        {
+          system,
+          pkgs,
+          self',
+          lib,
+          ...
         }:
         let
           nixvim' = nixvim.legacyPackages.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -48,18 +48,17 @@
               src = ./.;
               hooks = {
                 statix.enable = true;
-                nixpkgs-fmt.enable = true;
+                nixfmt.enable = true;
               };
             };
           };
 
-          formatter = pkgs.nixpkgs-fmt;
+          formatter = pkgs.nixfmt-rfc-style;
 
           packages.default = nvim;
 
           devShells = {
-            default = with pkgs;
-              mkShell { inherit (self'.checks.pre-commit-check) shellHook; };
+            default = with pkgs; mkShell { inherit (self'.checks.pre-commit-check) shellHook; };
           };
         };
     };


### PR DESCRIPTION
The rationale behind this PR is that `nixfmt-rfc-style` is pretty much the de facto formatter on nixpkgs and is slowly being adopted over the whole repo. This will make it easier to work on `nixpkgs` with nixvim

P.S: Is `💄`, the correct emoji for a chore? I don't quite understand this convention... 😅